### PR TITLE
Build on stable toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ widestring = "0.5"
 default = ["nethost", "nethost-download"]
 nethost-download = ["nethost-sys/download-nuget"]
 nethost = ["nethost-sys"]
+nightly = []
 
 # Prevent downloading nethost library when building on docs.rs.
 [package.metadata.docs.rs]

--- a/src/error/hosting_result.rs
+++ b/src/error/hosting_result.rs
@@ -1,7 +1,6 @@
-use std::{
-    convert::TryFrom,
-    ops::{ControlFlow, FromResidual, Try},
-};
+use std::convert::TryFrom;
+#[cfg(feature = "nightly")]
+use std::ops::{ControlFlow, FromResidual, Try};
 
 use crate::bindings;
 use derive_more::{Deref, Display, From};
@@ -117,6 +116,7 @@ impl From<HostingError> for HostingResult {
     }
 }
 
+#[cfg(feature = "nightly")]
 impl Try for HostingResult {
     type Output = HostingSuccess;
     type Residual = HostingError;
@@ -131,6 +131,7 @@ impl Try for HostingResult {
     }
 }
 
+#[cfg(feature = "nightly")]
 impl FromResidual for HostingResult {
     fn from_residual(r: HostingError) -> Self {
         HostingResult(Err(r))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(maybe_uninit_uninit_array, maybe_uninit_slice, try_trait_v2)]
+#![feature(try_trait_v2)]
 #![warn(clippy::pedantic, clippy::cargo, unsafe_op_in_unsafe_fn)]
 #![allow(
     clippy::missing_safety_doc,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(try_trait_v2)]
+#![cfg_attr(feature = "nightly", feature(try_trait_v2))]
 #![warn(clippy::pedantic, clippy::cargo, unsafe_op_in_unsafe_fn)]
 #![allow(
     clippy::missing_safety_doc,

--- a/src/nethost.rs
+++ b/src/nethost.rs
@@ -4,7 +4,7 @@ use crate::{
     hostfxr::Hostfxr,
     pdcstring::{self, PdCStr},
 };
-use std::{ffi::OsString, mem::MaybeUninit, ptr};
+use std::{ffi::OsString, ptr};
 use thiserror::Error;
 
 /// Gets the path to the hostfxr library.
@@ -34,7 +34,7 @@ pub fn get_hostfxr_path_with_dotnet_root<P: AsRef<PdCStr>>(
 unsafe fn get_hostfxr_path_with_parameters(
     parameters: *const get_hostfxr_parameters,
 ) -> Result<OsString, HostingError> {
-    let mut path_buffer = MaybeUninit::uninit_array::<MAX_PATH>();
+    let mut path_buffer = [0; MAX_PATH];
     let mut path_length = path_buffer.len();
 
     let result = unsafe {
@@ -47,25 +47,23 @@ unsafe fn get_hostfxr_path_with_parameters(
 
     match HostingResult::from(result).into_result() {
         Ok(_) => {
-            let path_slice =
-                unsafe { MaybeUninit::slice_assume_init_ref(&path_buffer[..path_length]) };
+            let path_slice = &path_buffer[..path_length];
             Ok(unsafe { PdCStr::from_slice_with_nul_unchecked(path_slice) }.to_os_string())
         }
         Err(HostingError::HostApiBufferTooSmall) => {
-            let mut path_vec = Vec::new();
-            path_vec.resize(path_length, MaybeUninit::<pdcstring::PdUChar>::uninit());
+            let mut path_vec: Vec<pdcstring::PdUChar> = Vec::new();
+            path_vec.resize(path_length, 0);
 
             let result = unsafe {
                 crate::bindings::nethost::get_hostfxr_path(
-                    path_vec[0].as_mut_ptr().cast(),
+                    &mut path_vec[0],
                     &mut path_length,
                     parameters,
                 )
             };
             assert_eq!(result as u32, HostingSuccess::Success.value());
 
-            let path_slice =
-                unsafe { MaybeUninit::slice_assume_init_ref(&path_vec[..path_length]) };
+            let path_slice = &path_vec[..path_length];
             Ok(unsafe { PdCStr::from_slice_with_nul_unchecked(path_slice) }.to_os_string())
         }
         Err(err) => Err(err),

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,5 +1,3 @@
-#![feature(option_result_unwrap_unchecked)]
-
 use netcorehost::{hostfxr::GetFunctionPointerError, nethost, pdcstr};
 
 #[path = "common.rs"]


### PR DESCRIPTION
Fixes #16

- Removes the unused feature `option_result_unwrap_unchecked`
- Removes the features `maybe_uninit_uninit_array` and `maybe_uninit_slice`. These could be made conditional, but I don't think it is worth the extra conditional compilation. The usage right now is preventing zeroing a ~260 byte array, which is done usually only once in the application.
- Makes the `try_trait_v2` conditional to the nightly toolchain

The `nightly` feature is set when using the nightly toolchain so this change works transparently. Compilation with nightly will include the try feature, while compilation with stable won't.

Tests pass on stable and nightly, with the exception of the `pdcstr` test. This test failed even before the change was introduced.