### PR TITLE
Fix ARM build

### DIFF
--- a/src/pdcstring/other.rs
+++ b/src/pdcstring/other.rs
@@ -1,4 +1,5 @@
 use std::ffi::{self, CStr, CString, OsStr, OsString};
+use std::os::raw::c_char;
 use std::os::unix::ffi::OsStrExt;
 use std::str::{self, FromStr};
 
@@ -36,7 +37,7 @@ impl PdCString {
         PdCString::from_vec(s.as_ref().as_bytes().to_vec())
     }
     #[must_use]
-    pub unsafe fn from_str_ptr(ptr: *const i8) -> Self {
+    pub unsafe fn from_str_ptr(ptr: *const c_char) -> Self {
         unsafe { PdCStr::from_str_ptr(ptr) }.to_owned()
     }
 }
@@ -80,11 +81,11 @@ impl PdCStr {
 // methods used by this crate
 impl PdCStr {
     #[must_use]
-    pub fn as_ptr(&self) -> *const i8 {
+    pub fn as_ptr(&self) -> *const c_char {
         self.0.as_ptr()
     }
     #[must_use]
-    pub unsafe fn from_str_ptr<'a>(ptr: *const i8) -> &'a Self {
+    pub unsafe fn from_str_ptr<'a>(ptr: *const c_char) -> &'a Self {
         let inner = unsafe { CStr::from_ptr(ptr) };
         PdCStr::from_inner(inner)
     }


### PR DESCRIPTION
The char type on ARM is unsigned, resulting in build errors due to the explicit use of i8. Replace these with c_char to fix.

Sample error (one of many):
```
error[E0308]: mismatched types
  --> src/hostfxr/library1_0.rs:50:63
   |
50 |                 .hostfxr_main(args.len().try_into().unwrap(), args.as_ptr())
   |                                                               ^^^^^^^^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*const *const u8`
              found raw pointer `*const *const i8`
```