### PR TITLE
Fix compilation without the nethost feature.

### DIFF
--- a/src/error/load_hostfxr_error.rs
+++ b/src/error/load_hostfxr_error.rs
@@ -1,0 +1,13 @@
+use crate::error::HostingError;
+use thiserror::Error;
+
+/// Enum for errors that can occur while locating and loading the hostfxr library.
+#[derive(Debug, Error)]
+pub enum LoadHostfxrError {
+    /// An error occured inside the hosting components.
+    #[error(transparent)]
+    Hosting(#[from] HostingError),
+    /// An error occured while loading the hostfxr library.
+    #[error(transparent)]
+    DlOpen(#[from] crate::dlopen2::Error),
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,5 +1,8 @@
 mod hosting_result;
 pub use hosting_result::*;
 
+mod load_hostfxr_error;
+pub use load_hostfxr_error::*;
+
 mod univ;
 pub use univ::*;

--- a/src/error/univ.rs
+++ b/src/error/univ.rs
@@ -13,11 +13,11 @@ pub enum Error {
     GetFunctionPointer(#[from] crate::hostfxr::GetManagedFunctionError),
     /// An error while loading the hostfxr library.
     #[error(transparent)]
-    LoadHostfxr(#[from] crate::nethost::LoadHostfxrError),
+    LoadHostfxr(#[from] crate::error::LoadHostfxrError),
 }
 
 impl From<crate::dlopen2::Error> for Error {
     fn from(err: crate::dlopen2::Error) -> Self {
-        Self::LoadHostfxr(crate::nethost::LoadHostfxrError::DlOpen(err))
+        Self::LoadHostfxr(crate::error::LoadHostfxrError::DlOpen(err))
     }
 }

--- a/src/hostfxr/library.rs
+++ b/src/hostfxr/library.rs
@@ -1,7 +1,6 @@
 use crate::{
     dlopen2::wrapper::Container,
-    error::{HostingError, HostingResult},
-    nethost::LoadHostfxrError,
+    error::{HostingError, HostingResult, LoadHostfxrError},
     pdcstring::PdCString,
 };
 use derive_more::From;

--- a/src/nethost.rs
+++ b/src/nethost.rs
@@ -5,7 +5,9 @@ use crate::{
     pdcstring::{self, PdCStr, PdUChar},
 };
 use std::{ffi::OsString, mem::MaybeUninit, ptr};
-use thiserror::Error;
+
+#[doc(no_inline)]
+pub use crate::error::LoadHostfxrError;
 
 /// Gets the path to the hostfxr library.
 pub fn get_hostfxr_path() -> Result<OsString, HostingError> {
@@ -98,17 +100,6 @@ pub fn load_hostfxr_with_dotnet_root<P: AsRef<PdCStr>>(
     let hostfxr_path = get_hostfxr_path_with_dotnet_root(dotnet_root)?;
     let hostfxr = Hostfxr::load_from_path(hostfxr_path)?;
     Ok(hostfxr)
-}
-
-/// Enum for errors that can occur while locating and loading the hostfxr library.
-#[derive(Debug, Error)]
-pub enum LoadHostfxrError {
-    /// An error occured inside the hosting components.
-    #[error(transparent)]
-    Hosting(#[from] HostingError),
-    /// An error occured while loading the hostfxr library.
-    #[error(transparent)]
-    DlOpen(#[from] crate::dlopen2::Error),
 }
 
 const unsafe fn maybe_uninit_slice_assume_init_ref<T>(slice: &[MaybeUninit<T>]) -> &[T] {


### PR DESCRIPTION
When trying to use the crate without the `nethost` feature, compilation fails because `crate::nethost::LoadHostfxrError` is referenced in other modules than `nethost`. This PR moves the error to the `error` module.